### PR TITLE
fix: use correct urn for v1 collections

### DIFF
--- a/src/resolvers.ts
+++ b/src/resolvers.ts
@@ -72,7 +72,7 @@ export async function resolveLegacyDclUrl(uri: URL) {
     if (uri.host == "base-avatars") {
       return internalResolver(`urn:decentraland:off-chain:base-avatars:${path[0]}`)
     } else {
-      return internalResolver(`urn:decentraland:collections-v1:${uri.host}:${path[0]}`)
+      return internalResolver(`urn:decentraland:ethereum:collections-v1:${uri.host}:${path[0]}`)
     }
   }
 }

--- a/test/urn.spec.ts
+++ b/test/urn.spec.ts
@@ -191,6 +191,19 @@ describe("Basic use cases", function () {
     expect(generatedUrl.toString()).toEqual("urn:decentraland:off-chain:base-avatars:eyes_03")
   })
 
+  it("legacy address (collections v1)", async () => {
+    expect(await parseUrn("dcl://halloween_2019/bride_of_frankie_earring")).toMatchObject({
+      id: "bride_of_frankie_earring",
+      namespace: "decentraland",
+      collectionName: "halloween_2019",
+      type: "blockchain-collection-v1",
+    })
+
+    const generatedUrl = (await parseUrn("dcl://halloween_2019/bride_of_frankie_earring")).uri
+
+    expect(generatedUrl.toString()).toEqual("urn:decentraland:ethereum:collections-v1:halloween_2019:bride_of_frankie_earring")
+  })
+
   it("legacy address (invalid)", async () => {
     expect(await parseUrn("dcl://base-avatars/")).toEqual(null)
     expect(await parseUrn("dcl://base-avatars")).toEqual(null)


### PR DESCRIPTION
We forgot to add the protocol to the urn generated when translating from old legacy dcl to urn, to urns