### PR TITLE
fix: use correct network for collection asset v1

### DIFF
--- a/src/resolvers.ts
+++ b/src/resolvers.ts
@@ -143,7 +143,7 @@ export async function resolveCollectionV1AssetByCollectionName(
     uri,
     blockchain: "ethereum",
     type: "blockchain-collection-v1-asset",
-    network: groups.protocol.toLowerCase(),
+    network: 'mainnet',
     contractAddress: (collection && collection.contractAddress) || null,
     id: groups.name,
     collectionName: (collection && collection.collectionId) || groups.collectionName,

--- a/test/urn.spec.ts
+++ b/test/urn.spec.ts
@@ -114,6 +114,20 @@ describe("Basic use cases", function () {
     })
   })
 
+  it("test collection v1 asset (with name)", async () => {
+    const r = await parseUrn(
+      "urn:decentraland:ethereum:collections-v1:community_contest:cw_bell_attendant_hat"
+    )
+    expect(r).toMatchObject({
+      type: "blockchain-collection-v1-asset",
+      blockchain: "ethereum",
+      network: "mainnet",
+      contractAddress: "0x32b7495895264ac9d0b12d32afd435453458b1c6",
+      collectionName: 'community_contest',
+      id: 'cw_bell_attendant_hat'
+    })
+  })
+
   it("test collection asset v2 (invalid id)", async () => {
     const r = await parseUrn(
       "urn:decentraland:ethereum:collections-v2:0xf87e31492faf9a91b02ee0deaad50d51d56d5d4d:test_name"


### PR DESCRIPTION
We were returning `ethereum` as the network in collection assets v1 (by name). All other assets return `mainnet`, so we made them consistent